### PR TITLE
zarr 2.13.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "zarr" %}
-{% set version = "2.8.1" %}
-{% set sha256 = "138e5f64bbaf7aece6da1f229b611a7a04742e15358dde49c6e9bae8404a3bf2" %}
+{% set version = "2.13.3" %}
+{% set sha256 = "db24b090616c638f65e33a6bc5d956d642221182961515ccbc28b17fb0d0b48c" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38]
+  # numcodecs >=0.10.0 is not available on s390x
+  skip: True  # [py<38 or s390x]
   script: {{PYTHON}} -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,9 @@ requirements:
 test:
   requires:
     - pytest
+    # Needs `pkg_resources` in the tests
+    # xref: https://github.com/zarr-developers/zarr-python/pull/813
+    - setuptools
   imports:
     - zarr
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
   script: {{PYTHON}} -m pip install --no-deps --ignore-installed .
 
 requirements:
-  build:
+  host:
     - python
     - pip
     - setuptools
@@ -54,7 +54,7 @@ about:
     Zarr is a format for the storage of chunked, compressed, N-dimensional arrays. 
     These documents describe the Zarr format and its Python implementation.
   dev_url: https://github.com/zarr-developers/zarr-python
-  doc_url: https://zarr.readthedocs.io/en/stable/
+  doc_url: https://zarr.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,22 +13,22 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<38]
   script: {{PYTHON}} -m pip install --no-deps --ignore-installed .
-  skip: True # [ppc64le]
 
 requirements:
   build:
-    - python >=3.6,<4
+    - python
     - pip
-    - setuptools >=38.6.0
-    - setuptools_scm >1.5.4
+    - setuptools
+    - setuptools_scm
+    - wheel
   run:
-    - python >=3.6,<4
+    - python
     - asciitree
     - numpy >=1.7
     - fasteners
-    - numcodecs >=0.6.4
+    - numcodecs >=0.10.0
 
 test:
   requires:
@@ -39,10 +39,16 @@ test:
     - pytest -v --pyargs zarr
 
 about:
-  home: https://github.com/zarr-developers/zarr
+  home: https://github.com/zarr-developers/zarr-python
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: An implementation of chunked, compressed, N-dimensional arrays for Python.
+  description: |
+    Zarr is a format for the storage of chunked, compressed, N-dimensional arrays. 
+    These documents describe the Zarr format and its Python implementation.
+  dev_url: https://github.com/zarr-developers/zarr-python
+  doc_url: https://zarr.readthedocs.io/en/stable/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
 
 test:
   requires:
+    - pip
     - pytest
     # Needs `pkg_resources` in the tests
     # xref: https://github.com/zarr-developers/zarr-python/pull/813
@@ -40,6 +41,7 @@ test:
   imports:
     - zarr
   commands:
+    - pip check
     - pytest -v --pyargs zarr
 
 about:


### PR DESCRIPTION
**Jira ticket:** [PKG-804](https://anaconda.atlassian.net/browse/PKG-804) (zarr 2.13.3)

**The upstream data:**
Changelog: https://github.com/zarr-developers/zarr-python/blob/v2.13.3/docs/release.rst
License: https://github.com/zarr-developers/zarr-python/blob/v2.13.3/LICENSE
Requirements:
- https://github.com/zarr-developers/zarr-python/blob/v2.13.3/pyproject.toml
- https://github.com/zarr-developers/zarr-python/blob/v2.13.3/setup.py

**_Actions:_**

1. Remove `noarch python`
2. Skip `py<38` and `s390x` (`numcodecs >=0.10.0` isn't available)
3. Fix `host` instead `build`
4. Remove `host` pinnings
5. Update `numcodecs` pinning
6. Add `setuptools` to `test/requires` because `zarr` needs `pkg_resources` in the tests, see https://github.com/zarr-developers/zarr-python/pull/813
7. Update `home` url
8. Add `license_family`
9. Add dev & doc urls
10. Add a `description`

**_Notes:_**
 * The downstream package `intake-xarray` https://github.com/AnacondaRecipes/intake-xarray-feedstock/pull/2 requires `xarray` https://github.com/AnacondaRecipes/xarray-feedstock/pull/10 with a new `zarr` and `numcodecs` https://github.com/AnacondaRecipes/numcodecs-feedstock/pull/7

**Package's statistics**
<details>

 * Priority C | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.13.3
 * Release on PyPi:
    * version: 2.13.3
    * date: 2022-10-09T09:42:59
* [PyPi history](https://pypi.org/project/zarr/#history)
 * Popularity: 
    * 3 months downloads: 12708.0
    * All time:  1903996 downloads -  zarr  2.13.3  An implementation of chunked, compressed, N-dimensional arrays for Python.  

</details>

**Other checks:**

<details>

11. - [x] Check the pinnings
13. - [x] Additional research
    https://github.com/zarr-developers/zarr-python/issues
14. - [x] `dev_url`:
    https://github.com/zarr-developers/zarr-python
16. - [x] Verify that the `build_number` is correct
17. - [x] has `setuptools`
18. - [x] Verify if the package needs `wheel`
19. - [x] `pip` in test
20. - [x] Verify the test section
21. - [x] Verify if the package is `architecture specific`
22. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
23.  - [x] license_file: LICENSE is present
24. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |

25. - [x] License family is present
    
</details>


**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/zarr-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/zarr-feedstock/tree/2.13.3)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/zarr)
* [Diff between upstream and feature branch](https://github.com/conda-forge/zarr-feedstock/compare/main...AnacondaRecipes:2.13.3)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/zarr-feedstock/compare/master...AnacondaRecipes:2.13.3)
* [The last merged PRs](https://github.com/AnacondaRecipes/zarr-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.13.3 git@github.com:AnacondaRecipes/zarr-feedstock.git
```
